### PR TITLE
Improves navigation

### DIFF
--- a/lib/src/app_router.dart
+++ b/lib/src/app_router.dart
@@ -4,27 +4,31 @@ import 'package:fit_and_healthy/src/features/tabs/tabs_view.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+final _rootNavigatorKey =
+    GlobalKey<NavigatorState>(debugLabel: 'Root Navigator');
+
 PreferredSizeWidget defaultAppBar =
     AppBar(title: Text('Fit and Healthy'), centerTitle: true);
 
 GoRouter appRouter = GoRouter(
+  navigatorKey: _rootNavigatorKey,
   routes: [
     StatefulShellRoute.indexedStack(
-        builder: (context, state, navigationShell) {
+        pageBuilder: (context, state, navigationShell) {
           PreferredSizeWidget appBar = defaultAppBar;
-          switch (navigationShell.currentIndex) {
-            case 0:
+          switch (state.fullPath) {
+            case DashboardView.route:
               appBar = DashboardAppbar;
               break;
-            case 1:
+            case '/exercise':
               // TODO: Should be defined in a separate file, like DashboardAppbar
               appBar = AppBar(title: Text('Exercise'), centerTitle: true);
               break;
-            case 2:
+            case '/nutrition':
               // TODO: Should be defined in a separate file, like DashboardAppbar
               appBar = AppBar(title: Text('Nutrition'), centerTitle: true);
               break;
-            case 3:
+            case '/something-else':
               // TODO: Should be defined in a separate file, like DashboardAppbar
               appBar = AppBar(title: Text('Something else'), centerTitle: true);
               break;
@@ -32,15 +36,17 @@ GoRouter appRouter = GoRouter(
               appBar = defaultAppBar;
           }
 
-          return TabsView(
-            navigationShell: navigationShell,
-            appBar: appBar,
+          return MaterialPage(
+            child: TabsView(
+              navigationShell: navigationShell,
+              appBar: appBar,
+            ),
           );
         },
         branches: [
           StatefulShellBranch(routes: [
             GoRoute(
-              path: '/',
+              path: DashboardView.route,
               builder: (context, state) => DashboardView(),
             ),
           ]),

--- a/lib/src/features/dashboard/dashboard_view.dart
+++ b/lib/src/features/dashboard/dashboard_view.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 class DashboardView extends StatelessWidget {
   const DashboardView({super.key});
 
+  static const route = '/';
+
   @override
   Widget build(BuildContext context) {
     return Container(

--- a/lib/src/features/tabs/tab_item.dart
+++ b/lib/src/features/tabs/tab_item.dart
@@ -5,7 +5,7 @@ class TabItem {
   final String title;
   final IconData icon;
   final String label;
-  final Function(StatefulNavigationShell) onTap;
+  final Function(StatefulNavigationShell, BuildContext) onTap;
 
   const TabItem({
     required this.title,

--- a/lib/src/features/tabs/tabs_data.dart
+++ b/lib/src/features/tabs/tabs_data.dart
@@ -1,39 +1,43 @@
 import 'package:fit_and_healthy/src/features/tabs/tab_item.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 List<TabItem> tabs = [
   TabItem(
     title: 'Dashboard',
     icon: Icons.home,
     label: 'Dashboard',
-    onTap: (navigationShell) => navigationShell.goBranch(0),
+    onTap: (navigationShell, context) =>
+        navigationShell.goBranch(0, initialLocation: true),
   ),
   TabItem(
     title: 'Exercise',
     icon: Icons.fitness_center,
     label: 'Exercise',
-    onTap: (navigationShell) => navigationShell.goBranch(1),
+    onTap: (navigationShell, context) =>
+        navigationShell.goBranch(1, initialLocation: true),
   ),
   TabItem(
     title: 'Add',
     icon: Icons.add,
     label: 'Add',
-    onTap: (navigationShell) => {
-      // TODO: Do something when clicking the add button
-      print('Add button clicked')
-    },
+    onTap: (navigationShell, context) => () => context.go(
+          context.namedLocation('add'),
+        ),
   ),
   TabItem(
     title: 'Nutrition',
     icon: Icons.restaurant,
     label: 'Nutrition',
-    onTap: (navigationShell) => navigationShell.goBranch(2),
+    onTap: (navigationShell, context) =>
+        navigationShell.goBranch(2, initialLocation: true),
   ),
   // "More" is a placeholder. We want 5 items in the bottom navigation bar, to make the add button centered, but have not yet decided what to put here.
   TabItem(
     title: 'More',
     icon: Icons.menu,
     label: 'More',
-    onTap: (navigationShell) => navigationShell.goBranch(3),
+    onTap: (navigationShell, context) =>
+        navigationShell.goBranch(3, initialLocation: true),
   ),
 ];

--- a/lib/src/features/tabs/tabs_view.dart
+++ b/lib/src/features/tabs/tabs_view.dart
@@ -37,7 +37,7 @@ class TabsView extends ConsumerWidget {
           NavigationBar(
             labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
             onDestinationSelected: (index) =>
-                tabs[index].onTap(navigationShell),
+                tabs[index].onTap(navigationShell, context),
             selectedIndex: _getTabIndex(),
             destinations: tabs
                 .map((tab) => NavigationDestination(


### PR DESCRIPTION
- Changes appbar handling of main navigation to use `state.fullPath` instead of `currentIndex` to allow for different appbars for subpages. Should probably use String.startsWith(<main route>) to handle having the same appbar for subroutes
- Adds `initialLocation: true` to support navigating to the main route of the main navigation branches by clicking on tthe active navigation item again.
- Adds a `_rootNavigatorKey` to the main GoRouter config to support pushing etc. on top of the main navigation to support pages with their own appbar and no bottom navbar

Closes #8 