### PR TITLE
Improve routing, fix use of nested Scaffolds, change to CupertinoPage

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,5 +1,6 @@
 import 'package:fit_and_healthy/src/app_router.dart';
 import 'package:fit_and_healthy/src/features/settings/settings_controller.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -26,7 +27,7 @@ class MyApp extends ConsumerWidget {
               child: CircularProgressIndicator(),
             );
           }
-          return MaterialApp.router(
+          return CupertinoApp.router(
             // Providing a restorationScopeId allows the Navigator built by the
             // MaterialApp to restore the navigation stack when a user leaves and
             // returns to the app after it has been killed while running in the
@@ -57,9 +58,12 @@ class MyApp extends ConsumerWidget {
             // Define a light and dark color theme. Then, read the user's
             // preferred ThemeMode (light, dark, or system default) from the
             // SettingsController to display the correct theme.
-            theme: ThemeData(),
-            darkTheme: ThemeData.dark(),
-            themeMode: snapshot.data!.themeMode,
+            theme: snapshot.data!.themeMode == ThemeMode.dark
+                ? CupertinoThemeData(brightness: Brightness.dark)
+                : CupertinoThemeData(brightness: Brightness.light),
+            // darkTheme: ThemeData.dark(),
+            // themeMode: snapshot.data!.themeMode,
+
             routerConfig: appRouter,
           );
         });

--- a/lib/src/app_router.dart
+++ b/lib/src/app_router.dart
@@ -1,12 +1,13 @@
-import 'package:fit_and_healthy/src/features/dashboard/dashboard_appbar.dart';
 import 'package:fit_and_healthy/src/features/dashboard/dashboard_view.dart';
 import 'package:fit_and_healthy/src/features/settings/pages/gdpr_settings_page.dart';
 import 'package:fit_and_healthy/src/features/settings/pages/goals_settings_page.dart';
 import 'package:fit_and_healthy/src/features/settings/pages/profile_settings_page.dart';
-import 'package:fit_and_healthy/src/features/settings/settings_appbar.dart';
 import 'package:fit_and_healthy/src/features/settings/settings_view.dart';
 import 'package:fit_and_healthy/src/features/exercise/exercise_workout_view.dart';
 import 'package:fit_and_healthy/src/features/tabs/tabs_view.dart';
+import 'package:fit_and_healthy/src/openfoodfacts/fooditemwidgets/foodSearchScreen.dart';
+import 'package:fit_and_healthy/src/openfoodfacts/mealCreationScreen.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:fit_and_healthy/src/features/exercise/exercise_data.dart';
@@ -24,30 +25,9 @@ GoRouter appRouter = GoRouter(
   routes: [
     StatefulShellRoute.indexedStack(
         pageBuilder: (context, state, navigationShell) {
-          PreferredSizeWidget appBar = defaultAppBar;
-          switch (state.fullPath) {
-            case DashboardView.route:
-              appBar = DashboardAppbar;
-              break;
-            case '/exercise':
-              // TODO: Should be defined in a separate file, like DashboardAppbar
-              appBar = AppBar(title: Text('Exercise'), centerTitle: true);
-              break;
-            case '/nutrition':
-              // TODO: Should be defined in a separate file, like DashboardAppbar
-              appBar = AppBar(title: Text('Nutrition'), centerTitle: true);
-              break;
-            case SettingsView.routeName:
-              appBar = SettingsAppBar;
-              break;
-            default:
-              appBar = defaultAppBar;
-          }
-
-          return MaterialPage(
+          return CupertinoPage(
             child: TabsView(
               navigationShell: navigationShell,
-              appBar: appBar,
             ),
           );
         },
@@ -55,41 +35,79 @@ GoRouter appRouter = GoRouter(
           StatefulShellBranch(routes: [
             GoRoute(
               path: DashboardView.route,
+              name: DashboardView.routeName,
               builder: (context, state) => DashboardView(),
             ),
           ]),
           StatefulShellBranch(routes: [
             GoRoute(
-              path: '/exercise',
-              builder: (context, state) =>
-                  ExerciseView(workouts: sampleWorkouts),
+                path: ExerciseView.route,
+                name: ExerciseView.routeName,
+                builder: (context, state) =>
+                    ExerciseView(workouts: sampleWorkouts),
+                routes: [
+                  // TODO: Switch to a routing based approach to navigate to the WorkoutDetailView. Use path parameters to pass the workout id.
+                  // GoRoute(
+                  //   path: WorkoutDetailView.route,
+                  //   builder: (context, state) {
+                  //     final workoutId = state.pathParameters['workoutId']!;
+                  //     final workout = sampleWorkouts
+                  //         .firstWhere((workout) => workout.id == workoutId);
+                  //     return WorkoutDetailView(workout: workout);
+                  //   },
+                  // )
+                ]),
+          ]),
+          StatefulShellBranch(routes: [
+            GoRoute(
+              path: NutritionScreen.route,
+              name: NutritionScreen.routeName,
+              builder: (context, state) => NutritionScreen(),
+              routes: [
+                GoRoute(
+                  path: FoodSearchScreen.route,
+                  name: FoodSearchScreen.routeName,
+                  builder: (context, state) => FoodSearchScreen(),
+                ),
+                GoRoute(
+                    path: MealListScreen.route,
+                    name: MealListScreen.routeName,
+                    builder: (context, state) {
+                      return MealListScreen();
+                    }),
+                // TODO: Use a route parameter to pass the mealId to the MealDetailScreen instead of passing the entire Meal
+                // GoRoute(
+                //     path: MealDetailScreen.route,
+                //     name: MealDetailScreen.routeName,
+                //     builder: (context, state) {
+                //       final mealId = state.pathParameters['mealId']!;
+                //       return MealDetailScreen(
+                //         mealId: mealId,
+                //       );
+                //     }),
+              ],
             ),
           ]),
           StatefulShellBranch(routes: [
             GoRoute(
-              path: '/nutrition',
-              builder: (context, state) =>
-                  NutritionScreen(), // Changed to use NutritionScreen for the Nutrition tab
-            ),
-          ]),
-          StatefulShellBranch(routes: [
-            GoRoute(
-                path: SettingsView.routeName,
+                path: SettingsView.route,
+                name: SettingsView.routeName,
                 builder: (context, state) => SettingsView(),
                 routes: [
                   GoRoute(
-                    path: ProfileSettingsPage.routeName,
-                    parentNavigatorKey: _rootNavigatorKey,
+                    path: ProfileSettingsPage.route,
+                    name: ProfileSettingsPage.routeName,
+                    // parentNavigatorKey: _rootNavigatorKey,
                     builder: (context, state) => ProfileSettingsPage(),
                   ),
                   GoRoute(
-                    path: GoalsSettingsPage.routeName,
-                    parentNavigatorKey: _rootNavigatorKey,
+                    path: GoalsSettingsPage.route,
+                    name: GoalsSettingsPage.routeName,
                     builder: (context, state) => GoalsSettingsPage(),
                   ),
                   GoRoute(
-                    path: GdprSettingsPage.routeName,
-                    parentNavigatorKey: _rootNavigatorKey,
+                    path: GdprSettingsPage.route,
+                    name: GdprSettingsPage.routeName,
                     builder: (context, state) => GdprSettingsPage(),
                   )
                 ]),

--- a/lib/src/features/dashboard/dashboard_appbar.dart
+++ b/lib/src/features/dashboard/dashboard_appbar.dart
@@ -1,4 +1,0 @@
-import 'package:flutter/material.dart';
-
-PreferredSizeWidget DashboardAppbar =
-    AppBar(title: const Text('Dashboard'), centerTitle: true);

--- a/lib/src/features/dashboard/dashboard_view.dart
+++ b/lib/src/features/dashboard/dashboard_view.dart
@@ -1,13 +1,20 @@
+import 'package:fit_and_healthy/src/nested_scaffold.dart';
 import 'package:flutter/material.dart';
 
 class DashboardView extends StatelessWidget {
   const DashboardView({super.key});
 
   static const route = '/';
+  static const routeName = 'Dashboard';
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return NestedScaffold(
+      appBar: AppBar(
+        title: const Text('Dashboard'),
+        centerTitle: true,
+      ),
+      body: Container(
         padding: const EdgeInsets.all(10),
         child: GridView.count(
           crossAxisCount: 2,
@@ -67,6 +74,8 @@ class DashboardView extends StatelessWidget {
               ),
             ),
           ],
-        ));
+        ),
+      ),
+    );
   }
 }

--- a/lib/src/features/exercise/exercise_appbar.dart
+++ b/lib/src/features/exercise/exercise_appbar.dart
@@ -1,4 +1,0 @@
-import 'package:flutter/material.dart';
-
-PreferredSizeWidget DashboardAppbar =
-    AppBar(title: const Text('Exercise'), centerTitle: true);

--- a/lib/src/features/exercise/exercise_workout_detail.dart
+++ b/lib/src/features/exercise/exercise_workout_detail.dart
@@ -1,3 +1,4 @@
+import 'package:fit_and_healthy/src/nested_scaffold.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:fit_and_healthy/shared/models/exercise.dart';
@@ -12,12 +13,15 @@ import 'package:fit_and_healthy/src/features/exercise/exercise_item.dart';
  * - Displays a message if no exercises are available in the workout.
  */
 class WorkoutDetailView extends StatelessWidget {
-  const WorkoutDetailView({
-    super.key,
-    required this.workout
-  });
+  const WorkoutDetailView({super.key, required this.workout});
 
   final Workout workout; // The workout to be displayed.
+
+  // TODO: Switch to a routing based approach to navigate to the WorkoutDetailView. Use path parameters to pass the workout id.
+  // static const route = '/exercise/workout-detail/:workoutId';
+  // WorkoutDetailView({required this.workoutId});
+  // final String workoutId;
+  // final Workout workout = <something>.getWorkoutById(workoutId);
 
   /**
    * The formatDate method, format the date as 'MMM d, yyyy'. 
@@ -39,7 +43,6 @@ class WorkoutDetailView extends StatelessWidget {
             style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 16),
-
           if (workout.exercises.isEmpty)
             Center(
               child: Text(
@@ -57,7 +60,7 @@ class WorkoutDetailView extends StatelessWidget {
       ),
     );
 
-    return Scaffold(
+    return NestedScaffold(
       appBar: AppBar(
         title: Text(workout.title),
       ),

--- a/lib/src/features/exercise/exercise_workout_view.dart
+++ b/lib/src/features/exercise/exercise_workout_view.dart
@@ -1,3 +1,4 @@
+import 'package:fit_and_healthy/src/nested_scaffold.dart';
 import 'package:flutter/material.dart';
 import 'package:fit_and_healthy/shared/models/exercise.dart';
 import 'package:fit_and_healthy/src/features/exercise/exercise_workout_detail.dart';
@@ -18,6 +19,9 @@ class ExerciseView extends StatelessWidget {
     required this.workouts,
   });
 
+  static const route = '/exercise';
+  static const routeName = 'Exercise';
+
   final List<Workout> workouts; // List of workouts to be displayed in the view.
 
   /**
@@ -27,6 +31,7 @@ class ExerciseView extends StatelessWidget {
    * [workout] - The selected Workout object to be passed to the detail view.
    */
   void selectWorkout(BuildContext context, Workout workout) {
+    // TODO: Switch to a routing based approach to navigate to the WorkoutDetailView. Use path parameters to pass the workout id.
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (ctx) => WorkoutDetailView(
@@ -36,15 +41,13 @@ class ExerciseView extends StatelessWidget {
     );
   }
 
- @override
+  @override
   Widget build(BuildContext context) {
     Widget content = SingleChildScrollView(
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(
-            'Uh oh ... nothing here!'
-          ),
+          Text('Uh oh ... nothing here!'),
           const SizedBox(height: 16),
           Text(
             'Try adding a workout session!',
@@ -63,16 +66,11 @@ class ExerciseView extends StatelessWidget {
           },
         ),
       );
-
-      return content;
     }
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('Workouts!'),
-      ),
+    return NestedScaffold(
+      appBar: AppBar(title: const Text('Exercise'), centerTitle: true),
       body: content,
     );
   }
 }
-

--- a/lib/src/features/settings/pages/gdpr_settings_page.dart
+++ b/lib/src/features/settings/pages/gdpr_settings_page.dart
@@ -1,13 +1,15 @@
+import 'package:fit_and_healthy/src/nested_scaffold.dart';
 import 'package:flutter/material.dart';
 
 class GdprSettingsPage extends StatelessWidget {
   const GdprSettingsPage({super.key});
 
-  static const routeName = '/gdpr';
+  static const route = '/gdpr';
+  static const routeName = 'GDPR Settings';
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return NestedScaffold(
       appBar: AppBar(
         title: Text("GDPR"),
       ),

--- a/lib/src/features/settings/pages/goals_settings_page.dart
+++ b/lib/src/features/settings/pages/goals_settings_page.dart
@@ -1,9 +1,11 @@
 import 'package:fit_and_healthy/shared/models/activity_level.dart';
+import 'package:fit_and_healthy/src/nested_scaffold.dart';
 import 'package:flutter/material.dart';
 import 'package:fit_and_healthy/shared/utils/calorie_calculator.dart';
 
 class GoalsSettingsPage extends StatefulWidget {
-  static const routeName = '/goals';
+  static const route = '/goals';
+  static const routeName = 'Goals Settings';
 
   _GoalsSettingsPage createState() => _GoalsSettingsPage();
 }
@@ -33,7 +35,7 @@ class _GoalsSettingsPage extends State<GoalsSettingsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return NestedScaffold(
       appBar: AppBar(
         title: Text("Goals"),
       ),

--- a/lib/src/features/settings/pages/profile_settings_page.dart
+++ b/lib/src/features/settings/pages/profile_settings_page.dart
@@ -1,13 +1,15 @@
+import 'package:fit_and_healthy/src/nested_scaffold.dart';
 import 'package:flutter/material.dart';
 
 class ProfileSettingsPage extends StatelessWidget {
   const ProfileSettingsPage({super.key});
 
-  static const routeName = '/profile';
+  static const route = '/profile';
+  static const routeName = 'Profile Settings';
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return NestedScaffold(
       appBar: AppBar(
         title: Text("Profile"),
       ),

--- a/lib/src/features/settings/settings_view.dart
+++ b/lib/src/features/settings/settings_view.dart
@@ -1,4 +1,9 @@
+import 'package:fit_and_healthy/src/features/settings/pages/gdpr_settings_page.dart';
+import 'package:fit_and_healthy/src/features/settings/pages/goals_settings_page.dart';
+import 'package:fit_and_healthy/src/features/settings/pages/profile_settings_page.dart';
+import 'package:fit_and_healthy/src/features/settings/settings_appbar.dart';
 import 'package:fit_and_healthy/src/features/settings/settings_controller.dart';
+import 'package:fit_and_healthy/src/nested_scaffold.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -10,7 +15,8 @@ import 'package:go_router/go_router.dart';
 class SettingsView extends ConsumerWidget {
   const SettingsView({super.key});
 
-  static const routeName = '/settings';
+  static const route = '/settings';
+  static const routeName = 'Settings';
 
   //final SettingsController controller;
 
@@ -18,7 +24,8 @@ class SettingsView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final settingsState = ref.watch(settingsControllerProvider).value;
 
-    return Scaffold(
+    return NestedScaffold(
+      appBar: SettingsAppBar,
       body: Column(
         children: [
           Column(
@@ -27,28 +34,28 @@ class SettingsView extends ConsumerWidget {
                 title: Text('Profile'),
                 leading: Icon(Icons.person),
                 onTap: () {
-                  context.push('/settings/profile');
+                  context.pushNamed(ProfileSettingsPage.routeName);
                 },
               ),
               ListTile(
                 title: Text('Widgets'),
                 leading: Icon(Icons.widgets),
                 onTap: () {
-                  context.push('/settings/profile');
+                  context.pushNamed(ProfileSettingsPage.routeName);
                 },
               ),
               ListTile(
                 title: Text('Goals'),
                 leading: Icon(Icons.star),
                 onTap: () {
-                  context.push('/settings/goals');
+                  context.pushNamed(GoalsSettingsPage.routeName);
                 },
               ),
               ListTile(
                 title: Text('GDPR'),
                 leading: Icon(Icons.document_scanner),
                 onTap: () {
-                  context.push('/settings/gdpr');
+                  context.pushNamed(GdprSettingsPage.routeName);
                 },
               ),
             ],

--- a/lib/src/features/tabs/tabs_view.dart
+++ b/lib/src/features/tabs/tabs_view.dart
@@ -4,14 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 class TabsView extends ConsumerWidget {
-  const TabsView(
-      {super.key,
-      this.appBar,
-      this.bottomNavigationBar,
-      required this.navigationShell});
+  const TabsView({super.key, required this.navigationShell});
 
-  final PreferredSizeWidget? appBar;
-  final Widget? bottomNavigationBar;
   final StatefulNavigationShell navigationShell;
 
   @override
@@ -26,26 +20,24 @@ class TabsView extends ConsumerWidget {
         case 3:
           return index + 1;
         default:
-          return 1;
+          return 0;
       }
     }
 
     return Scaffold(
-      appBar: appBar,
       body: navigationShell,
-      bottomNavigationBar: bottomNavigationBar ??
-          NavigationBar(
-            labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
-            onDestinationSelected: (index) =>
-                tabs[index].onTap(navigationShell, context),
-            selectedIndex: _getTabIndex(),
-            destinations: tabs
-                .map((tab) => NavigationDestination(
-                      icon: Icon(tab.icon),
-                      label: tab.label,
-                    ))
-                .toList(),
-          ),
+      bottomNavigationBar: NavigationBar(
+        labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
+        onDestinationSelected: (index) =>
+            tabs[index].onTap(navigationShell, context),
+        selectedIndex: _getTabIndex(),
+        destinations: tabs
+            .map((tab) => NavigationDestination(
+                  icon: Icon(tab.icon),
+                  label: tab.label,
+                ))
+            .toList(),
+      ),
     );
   }
 }

--- a/lib/src/nested_scaffold.dart
+++ b/lib/src/nested_scaffold.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+class NestedScaffold extends StatelessWidget {
+  const NestedScaffold(
+      {super.key,
+      this.appBar,
+      this.body,
+      this.floatingActionButton,
+      this.floatingActionButtonLocation,
+      this.floatingActionButtonAnimator,
+      this.persistentFooterButtons,
+      this.persistentFooterAlignment = AlignmentDirectional.centerEnd,
+      this.drawer,
+      this.onDrawerChanged,
+      this.endDrawer,
+      this.onEndDrawerChanged,
+      this.bottomSheet,
+      this.backgroundColor,
+      this.primary = true,
+      this.drawerDragStartBehavior = DragStartBehavior.start,
+      this.extendBody = false,
+      this.extendBodyBehindAppBar = false,
+      this.drawerScrimColor,
+      this.drawerEdgeDragWidth,
+      this.drawerEnableOpenDragGesture = true,
+      this.endDrawerEnableOpenDragGesture = true,
+      this.restorationId});
+
+  final PreferredSizeWidget? appBar;
+  final Widget? body;
+  final Widget? floatingActionButton;
+  final FloatingActionButtonLocation? floatingActionButtonLocation;
+  final FloatingActionButtonAnimator? floatingActionButtonAnimator;
+  final List<Widget>? persistentFooterButtons;
+  final AlignmentDirectional persistentFooterAlignment;
+  final Widget? drawer;
+  final void Function(bool)? onDrawerChanged;
+  final Widget? endDrawer;
+  final void Function(bool)? onEndDrawerChanged;
+  final Widget? bottomSheet;
+  final Color? backgroundColor;
+  final bool primary;
+  final DragStartBehavior drawerDragStartBehavior;
+  final bool extendBody;
+  final bool extendBodyBehindAppBar;
+  final Color? drawerScrimColor;
+  final double? drawerEdgeDragWidth;
+  final bool drawerEnableOpenDragGesture;
+  final bool endDrawerEnableOpenDragGesture;
+  final String? restorationId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: appBar,
+      body: body,
+      floatingActionButton: floatingActionButton,
+      floatingActionButtonLocation: floatingActionButtonLocation,
+      floatingActionButtonAnimator: floatingActionButtonAnimator,
+      persistentFooterButtons: persistentFooterButtons,
+      persistentFooterAlignment: persistentFooterAlignment,
+      drawer: drawer,
+      onDrawerChanged: onDrawerChanged,
+      endDrawer: endDrawer,
+      onEndDrawerChanged: onEndDrawerChanged,
+      bottomSheet: bottomSheet,
+      backgroundColor: backgroundColor,
+      primary: primary,
+      drawerDragStartBehavior: drawerDragStartBehavior,
+      extendBody: extendBody,
+      extendBodyBehindAppBar: extendBodyBehindAppBar,
+      drawerScrimColor: drawerScrimColor,
+      drawerEdgeDragWidth: drawerEdgeDragWidth,
+      drawerEnableOpenDragGesture: drawerEnableOpenDragGesture,
+      endDrawerEnableOpenDragGesture: endDrawerEnableOpenDragGesture,
+      restorationId: restorationId,
+
+      // N.B. This widget should never have a bottomNavigationBar nor resizeToAvoidBottomInset as its supposed to be nested within the main app's Scaffold
+      resizeToAvoidBottomInset: false,
+      bottomNavigationBar: null,
+    );
+  }
+}

--- a/lib/src/openfoodfacts/fooditemwidgets/foodSearchScreen.dart
+++ b/lib/src/openfoodfacts/fooditemwidgets/foodSearchScreen.dart
@@ -1,4 +1,5 @@
 // FoodSearchScreen.dart
+import 'package:fit_and_healthy/src/nested_scaffold.dart';
 import 'package:flutter/material.dart';
 
 import '../foodrelatedclasses/fooditem.dart';
@@ -6,6 +7,9 @@ import '../openFoodApi.dart';
 import 'fooditemwidget.dart';
 
 class FoodSearchScreen extends StatefulWidget {
+  static const route = '/search';
+  static const routeName = 'Nutrition Search';
+
   @override
   _FoodSearchScreenState createState() => _FoodSearchScreenState();
 }
@@ -35,7 +39,7 @@ class _FoodSearchScreenState extends State<FoodSearchScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return NestedScaffold(
       appBar: AppBar(
         title: Text('Search Products'),
         centerTitle: true,

--- a/lib/src/openfoodfacts/mealCreationScreen.dart
+++ b/lib/src/openfoodfacts/mealCreationScreen.dart
@@ -1,3 +1,4 @@
+import 'package:fit_and_healthy/src/nested_scaffold.dart';
 import 'package:fit_and_healthy/src/openfoodfacts/foodrelatedclasses/mealClass.dart';
 import 'package:fit_and_healthy/src/openfoodfacts/foodrelatedclasses/mealHolderClass.dart';
 import 'package:flutter/material.dart';
@@ -5,6 +6,9 @@ import 'package:flutter/material.dart';
 import 'mealDetailScreen.dart';
 
 class MealListScreen extends StatefulWidget {
+  static const route = '/create-meal';
+  static const routeName = 'Create Meal';
+
   @override
   _MealListScreenState createState() => _MealListScreenState();
 }
@@ -29,7 +33,7 @@ class _MealListScreenState extends State<MealListScreen> {
   Widget build(BuildContext context) {
     final totalNutrition = mealHolder.calculateTotalNutrition();
 
-    return Scaffold(
+    return NestedScaffold(
       appBar: AppBar(
         title: Text(
             'Meals on ${mealHolder.date.toLocal().toString().split(' ')[0]}'), // Display date
@@ -69,6 +73,7 @@ class _MealListScreenState extends State<MealListScreen> {
                     onPressed: () => _removeMeal(meal.id), // Remove meal by ID
                   ),
                   onTap: () {
+                    // TODO: Switch to a routing based approach to navigate to the MealDetailScreen. Use path parameters to pass the meal id.
                     Navigator.push(
                       context,
                       MaterialPageRoute(

--- a/lib/src/openfoodfacts/mealDetailScreen.dart
+++ b/lib/src/openfoodfacts/mealDetailScreen.dart
@@ -1,13 +1,20 @@
+import 'package:fit_and_healthy/src/openfoodfacts/foodrelatedclasses/mealClass.dart';
 import 'package:flutter/material.dart';
 
 import 'foodrelatedclasses/fooditem.dart';
-import 'foodrelatedclasses/mealClass.dart';
 import 'openFoodApi.dart';
 
 class MealDetailScreen extends StatefulWidget {
   final Meal meal;
 
   MealDetailScreen({required this.meal});
+
+  // TODO: Switch to using a routing-based solutions by going to the id of the meal
+  // final String mealId;
+  // static const route = '/meal-detail/:mealId';
+  // static const routeName = 'Meal Details';
+  // MealDetailScreen({required this.mealId});
+  // final Meal meal = MealHolder.getMealById(mealId);
 
   @override
   _MealDetailScreenState createState() => _MealDetailScreenState();

--- a/lib/src/openfoodfacts/nutritionScreen.dart
+++ b/lib/src/openfoodfacts/nutritionScreen.dart
@@ -1,35 +1,34 @@
 // NutritionScreen.dart
 
+import 'package:fit_and_healthy/src/nested_scaffold.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'fooditemwidgets/foodSearchScreen.dart';
 import 'mealCreationScreen.dart';
 
 class NutritionScreen extends StatelessWidget {
+  static const route = '/nutrition';
+  static const routeName = 'Nutrition';
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(),
+    return NestedScaffold(
+      appBar: AppBar(title: Text('Nutrition'), centerTitle: true),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             ElevatedButton(
               onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => FoodSearchScreen()),
-                );
+                context.pushNamed(FoodSearchScreen.routeName);
               },
               child: Text('Add Food'),
             ),
             SizedBox(height: 20), // Add spacing between buttons
             ElevatedButton(
               onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => MealListScreen()),
-                );
+                context.pushNamed(MealListScreen.routeName);
               },
               child: Text(
                   'Create Meal'), // Button for navigating to MealBuilderWidget


### PR DESCRIPTION
- Changes to CupertinoPages in our application to get prettier and more user friendly page transitions.
- Created a new NestedScaffold class to be used in pages where you want to keep the bottom navigation, but still have a Scaffold for AppBar or similar.
- Removes old AppBar switch logic, moves AppBars into the screen classes
- Adds proper routes for the sub-screens of the different tabs
- Adds a routeName variable in each screen class to be used for named navigation. e.g. `context.pushNamed(ProfileSettingsPage.routeName);`
- Adds TODOs to explain how to add path parameters in the future. e.g. `/nutrition/meal/:mealId` to navigate to the screen for that specific meal. Where `:mealId` would be replaced with the wanted meal ID

Closes #20 